### PR TITLE
fix #203: set delete parameter to False so that the temp file can be opened a second time on Windows

### DIFF
--- a/runners/mujoco/revolve2/runners/mujoco/_local_runner.py
+++ b/runners/mujoco/revolve2/runners/mujoco/_local_runner.py
@@ -287,7 +287,7 @@ class LocalRunner(Runner):
                 ) as botfile:
                     mujoco.mj_saveLastXML(botfile.name, model)
                     robot = mjcf.from_file(botfile)
-            # handle an exception when tthe xml saving fails, it's almost certain to occur on Windows
+            # handle an exception when the xml saving fails, it's almost certain to occur on Windows
             # since NamedTemporaryFile can't be opened twice when the file is still open.
             except Exception as e:
                 print(repr(e))

--- a/runners/mujoco/revolve2/runners/mujoco/_local_runner.py
+++ b/runners/mujoco/revolve2/runners/mujoco/_local_runner.py
@@ -282,10 +282,13 @@ class LocalRunner(Runner):
             # mujoco can only save to a file, not directly to string,
             # so we create a temporary file.
             with tempfile.NamedTemporaryFile(
-                mode="r+", delete=True, suffix="_mujoco.urdf"
+                mode="r+", delete=False, suffix="_mujoco.urdf"
             ) as botfile:
                 mujoco.mj_saveLastXML(botfile.name, model)
                 robot = mjcf.from_file(botfile)
+            # if the temporary file still exists, delete it
+            if os.path.isfile(botfile.name):
+                os.remove(botfile.name)
 
             for joint in posed_actor.actor.joints:
                 robot.actuator.add(


### PR DESCRIPTION
As per subject, this fixes #203. 

I've tested it on both Linux and Windows.