### PR TITLE
speed up simulation by reducing timestep

### DIFF
--- a/runners/mujoco/revolve2/runners/mujoco/_local_runner.py
+++ b/runners/mujoco/revolve2/runners/mujoco/_local_runner.py
@@ -249,7 +249,7 @@ class LocalRunner(Runner):
 
         env_mjcf.compiler.angle = "radian"
 
-        env_mjcf.option.timestep = 0.0005
+        env_mjcf.option.timestep = 0.002
         env_mjcf.option.integrator = "RK4"
 
         env_mjcf.option.gravity = [0, 0, -9.81]


### PR DESCRIPTION
Increased the timestep used in mujoco runner. This is still stable for experiments I tried but makes everything significantly faster. Can maybe be made a user option if it turns out it needs to be tuned often.