### PR TITLE
Fix core installation errors for codecov package

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -21,7 +21,6 @@ setup(
     install_requires=[
         f"revolve2-actor-controller @ file://{os.path.join(revolve2_path, 'actor_controller')}",
         "numpy>=1.21.2",
-        "rootpath>=0.1.1",
         "matplotlib>=3.4.3",
         "scipy>=1.7.1",
         "pyrr>=0.10.3",
@@ -29,7 +28,6 @@ setup(
         "asyncssh>=2.9.0",
         "aiosqlite>=0.17.0",
         "pandas>=1.4.2",
-        "codecov @ git+https://github.com/codecov/codecov-python.git@v2.1.12",
     ],
     extras_require={"dev": ["sqlalchemy[mypy]>=1.4.28"]},
     zip_safe=False,

--- a/core/setup.py
+++ b/core/setup.py
@@ -29,7 +29,7 @@ setup(
         "asyncssh>=2.9.0",
         "aiosqlite>=0.17.0",
         "pandas>=1.4.2",
-        "codecov @ git+ssh://git@github.com/codecov/codecov-python.git@v2.1.12",
+        "codecov @ git+https://github.com/codecov/codecov-python.git@v2.1.12",
     ],
     extras_require={"dev": ["sqlalchemy[mypy]>=1.4.28"]},
     zip_safe=False,

--- a/core/setup.py
+++ b/core/setup.py
@@ -29,6 +29,7 @@ setup(
         "asyncssh>=2.9.0",
         "aiosqlite>=0.17.0",
         "pandas>=1.4.2",
+        "codecov @ git+ssh://git@github.com/codecov/codecov-python.git@v2.1.12",
     ],
     extras_require={"dev": ["sqlalchemy[mypy]>=1.4.28"]},
     zip_safe=False,


### PR DESCRIPTION
When pip installing the `core` package, the following errors ocurr, 

```
ERROR: Could not find a version that satisfies the requirement codecov>=2.0.15 (from rootpath) (from versions: none)
ERROR: No matching distribution found for codecov>=2.0.15
```

It appears that one of [rootpath dependencies](https://github.com/grimen/python-rootpath/blob/master/requirements.txt#L11), codecov, is [no longer hosted on PyPI](https://pypi.org/project/codecov/). To fix this issue, I added `codedov` directly from the [Github repository](https://github.com/codecov/codecov-python) to the `install_requires` list.