### PR TITLE
Add armature to hinges

### DIFF
--- a/runners/mujoco/revolve2/runners/mujoco/_local_runner.py
+++ b/runners/mujoco/revolve2/runners/mujoco/_local_runner.py
@@ -347,6 +347,9 @@ class LocalRunner(Runner):
                         os.remove(botfile.name)
 
             for joint in posed_actor.actor.joints:
+                # Add rotor inertia to joints. This value is arbitrarily chosen and appears stable enough.
+                # Fine-tuning the armature value might be needed later.
+                robot.find(namespace="joint", identifier=joint.name).armature = "0.002"
                 robot.actuator.add(
                     "position",
                     kp=5.0,


### PR DESCRIPTION
Add armature to hinges to make the simulation more stable. The armature value is arbitrarily chosen and it seems stable enough. Tuning might be needed later.