### PR TITLE
CPG brain sets hinge targets based on their range instead of [-1, 1].

### DIFF
--- a/modular_robot/revolve2/modular_robot/body/v1/_active_hinge_v1.py
+++ b/modular_robot/revolve2/modular_robot/body/v1/_active_hinge_v1.py
@@ -24,7 +24,7 @@ class ActiveHingeV1(ActiveHinge):
             num_children=1,
             rotation=rotation,
             color=self._COLOR,
-            range=1.047197551,
+            range=1.047197551,  # 60 degrees
             effort=0.948013269,  # motor specs: 9.4 kgfcm at 4.8V or 11 kgfcm at 6.0V -> at 5.0V: 9.6667 * 9.807 / 100
             velocity=6.338968228,  # motor specs: 0.17  at 4.8V or 0.14 s/60deg at 6.0V -> at 5.0V: 1 / 0.1652 * 60 / 360 * 2pi
             frame_bounding_box=Vector3([0.018, 0.053, 0.0165891]),

--- a/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_instance.py
+++ b/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_instance.py
@@ -18,9 +18,6 @@ class BrainCpgInstance(BrainInstance):
     The outputs of the controller are defined by the `outputs`, a list of indices for the state array.
     """
 
-    TARGET_CLIPPING = 1.0
-    """When setting a target, the corresponding state value is clipped between -TARGET_CLIPPING and TARGET_CLIPPING."""
-
     _initial_state: npt.NDArray[np.float_]
     _weight_matrix: npt.NDArray[np.float_]  # nxn matrix matching number of neurons
     _output_mapping: list[tuple[int, ActiveHinge]]
@@ -79,10 +76,5 @@ class BrainCpgInstance(BrainInstance):
         # Set active hinge targets to match newly calculated state.
         for state_index, active_hinge in self._output_mapping:
             control_interface.set_active_hinge_target(
-                active_hinge,
-                np.clip(
-                    self._state[state_index],
-                    a_min=-self.TARGET_CLIPPING,
-                    a_max=self.TARGET_CLIPPING,
-                ),
+                active_hinge, self._state[state_index] * active_hinge.range
             )

--- a/modular_robot_simulation/revolve2/modular_robot_simulation/_modular_robot_control_interface_impl.py
+++ b/modular_robot_simulation/revolve2/modular_robot_simulation/_modular_robot_control_interface_impl.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from revolve2.modular_robot import ModularRobotControlInterface
 from revolve2.modular_robot.body.base import ActiveHinge
 from revolve2.simulation.scene import ControlInterface, UUIDKey
@@ -36,5 +38,5 @@ class ModularRobotControlInterfaceImpl(ModularRobotControlInterface):
             self._body_to_multi_body_system_mapping.active_hinge_to_joint_hinge[
                 UUIDKey(active_hinge)
             ],
-            target,
+            np.clip(target, a_min=-active_hinge.range, a_max=active_hinge.range),
         )


### PR DESCRIPTION
* CPG brain sets hinge targets based on their range instead of [-1, 1].
* Removed clipping from CPG.
* Added clipping to modular robot control interface.

closes #333 