### PR TITLE
374 Remove Scipy Dependency

### DIFF
--- a/simulation/pyproject.toml
+++ b/simulation/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 name = "revolve2-simulation"
 version = "1.0.0rc1"
 description = "Revolve2: Physics simulation abstraction layer."
-authors = ["Aart Stuurman <aartstuurman@hotmail.com>"]
+authors = ["Aart Stuurman <aartstuurman@hotmail.com>", "Oliver Weissl <o.weissl@vu.nl>"]
 repository = "https://github.com/ci-group/revolve2"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -23,7 +23,6 @@ packages = [{ include = "revolve2" }]
 
 [tool.poetry.dependencies]
 python = "^3.10,<3.12"
-scipy = "^1.7.1"
 pyrr = "^0.10.3"
 
 [tool.poetry.extras]

--- a/simulation/revolve2/simulation/scene/conversion/_multi_body_system_to_urdf.py
+++ b/simulation/revolve2/simulation/scene/conversion/_multi_body_system_to_urdf.py
@@ -1,9 +1,8 @@
 import uuid
-import warnings
 import xml.dom.minidom as minidom
 import xml.etree.ElementTree as xml
+from math import atan2, sqrt
 
-import scipy.spatial.transform
 from pyrr import Quaternion, Vector3
 
 from .._joint_hinge import JointHinge
@@ -323,12 +322,18 @@ class _URDFConverter:
 
 
 def _quaternion_to_euler(quaternion: Quaternion) -> Vector3:
-    with warnings.catch_warnings():
-        warnings.simplefilter(
-            "ignore", UserWarning
-        )  # ignore gimbal lock warning. it is irrelevant for us.
-        euler = scipy.spatial.transform.Rotation.from_quat(
-            [quaternion.x, quaternion.y, quaternion.z, quaternion.w]
-        ).as_euler("xyz")
+    """
+    Convert a Quaternion to euler angles.
 
-    return Vector3(euler)
+    If you want to see the maths behind this check the following page: https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles .
+
+    :param quaternion: The quaternion to convert.
+    :return: Euler angles in form of a Vector3 (roll, pitch, yaw).
+    """
+    w, x, y, z = quaternion
+
+    roll = atan2(2 * (w * x + y * z), 1 - 2 * (x * x + y * y))
+    pitch = atan2(sqrt(1 + 2 * (w * y - x * z)), sqrt(1 - 2 * (w * y - x * z)))
+    yaw = atan2(2 * (w * z + x * y), 1 - 2 * (y * y + z * z))
+
+    return Vector3([roll, pitch, yaw])

--- a/simulation/revolve2/simulation/scene/conversion/_multi_body_system_to_urdf.py
+++ b/simulation/revolve2/simulation/scene/conversion/_multi_body_system_to_urdf.py
@@ -1,3 +1,4 @@
+import math
 import uuid
 import xml.dom.minidom as minidom
 import xml.etree.ElementTree as xml
@@ -333,7 +334,10 @@ def _quaternion_to_euler(quaternion: Quaternion) -> Vector3:
     w, x, y, z = quaternion
 
     roll = atan2(2 * (w * x + y * z), 1 - 2 * (x * x + y * y))
-    pitch = atan2(sqrt(1 + 2 * (w * y - x * z)), sqrt(1 - 2 * (w * y - x * z)))
+    pitch = (
+        2 * atan2(sqrt(1 + 2 * (w * y - x * z)), sqrt(1 - 2 * (w * y - x * z)))
+        - math.pi / 2
+    )
     yaw = atan2(2 * (w * z + x * y), 1 - 2 * (y * y + z * z))
 
     return Vector3([roll, pitch, yaw])


### PR DESCRIPTION
Scipy is only used once for conversion of quaternion to eulers. 
This can be easily done using math library, while removing one package from requirements.

closes #374 