### PR TITLE
402 v2 simulation bug fix

### DIFF
--- a/ci_group/revolve2/ci_group/genotypes/cppnwin/modular_robot/v2/_body_develop.py
+++ b/ci_group/revolve2/ci_group/genotypes/cppnwin/modular_robot/v2/_body_develop.py
@@ -41,11 +41,18 @@ def develop(
 
     body = BodyV2()
 
-    to_explore.put(
-        __Module(
-            Vector3([0, 0, 0]), Vector3([0, -1, 0]), Vector3([0, 0, 1]), 0, body.core
+    v2_core = body.core_v2
+
+    for attachment_face in v2_core.attachment_faces.values():
+        to_explore.put(
+            __Module(
+                Vector3([0, 0, 0]),
+                Vector3([0, -1, 0]),
+                Vector3([0, 0, 1]),
+                0,
+                attachment_face,
+            )
         )
-    )
     grid[0, 0, 0] = 1
     part_count = 1
 
@@ -114,9 +121,8 @@ def __add_child(
         return None
     grid[grid_pos] += 1
 
-    child_type, child_rotation = __evaluate_cppn(
-        body_net, position + attachment_point.offset, chain_length
-    )
+    new_pos = np.array(np.round(position + attachment_point.offset), dtype=np.int64)
+    child_type, child_rotation = __evaluate_cppn(body_net, new_pos, chain_length)
     child_orientation = __make_quaternion_from_index(child_rotation)
     if child_type is None or not module.module_reference.can_set_child(
         child := child_type(child_orientation.angle), attachment_index

--- a/modular_robot/revolve2/modular_robot/body/base/_attachment_face.py
+++ b/modular_robot/revolve2/modular_robot/body/base/_attachment_face.py
@@ -1,71 +1,29 @@
-from abc import abstractmethod
-from dataclasses import dataclass, field
-
 from .._attachment_point import AttachmentPoint
+from .._color import Color
 from .._module import Module
+from .._right_angles import RightAngles
 
 
-@dataclass
-class AttachmentFace:
-    """Collect AttachmentPoints on a modules face."""
+class AttachmentFace(Module):
+    """
+    Collect AttachmentPoints on a modules face.
 
-    _attachment_points: dict[int, AttachmentPoint] = field(default_factory=lambda: {})
-    _mounted_modules: dict[int, Module] = field(default_factory=lambda: {})
+    This face can be thought of as a pseudo-module which usually does not have a body on its own.
+    """
 
-    def add_attachment_point(
+    def __init__(
         self,
-        index: int,
-        attachment_point: AttachmentPoint,
-        allow_repopulation: bool = False,
+        rotation: float | RightAngles,
+        attachment_points: dict[int, AttachmentPoint],
     ) -> None:
         """
-        Add an attachment point to the Face.
+        Initialize this object.
 
-        :param index: The index of the attachment point.
-        :param attachment_point: The attachment point.
-        :param allow_repopulation: If setting a new attachment point onto a previously existing one is allowed.
+        :param rotation: Orientation of this model relative to its parent.
+        :param attachment_points: The attachment points available on a module.
         """
-        if not allow_repopulation:
-            assert self._attachment_points.get(index) is None, "Index is already used."
-
-        self._attachment_points[index] = attachment_point
-
-    def mount_module(
-        self, index: int, module: Module, ignore_conflict: bool = False
-    ) -> bool:
-        """
-        Mount a Module onto a attachment point.
-
-        :param index: The index of the attachment point.
-        :param module: The module.
-        :param ignore_conflict: Ignore potential errors when mounting to attachment_point.
-        :return: If successful or not.
-        """
-        if not self._check_for_conflict(index, module, ignore_conflict):
-            self._mounted_modules[index] = module
-            return True
-        return False
-
-    @property
-    def attachment_points(self) -> dict[int, AttachmentPoint]:
-        """
-        Get the attachment points.
-
-        :return: The attachment points.
-        """
-        return self._attachment_points
-
-    @abstractmethod
-    def _check_for_conflict(
-        self, index: int, module: Module, ignore_conflict: bool
-    ) -> bool:
-        """
-        Check for conflicts when adding a new attachment point.
-
-        :param index: The index of the attachment point.
-        :param module: The module.
-        :param ignore_conflict: Ignore potential errors when adding attachment_point.
-        :raises Exception: If the attachment point causes conflicts.
-        :return: If conflicts occurred.
-        """
-        pass
+        super().__init__(
+            rotation=rotation,
+            attachment_points=attachment_points,
+            color=Color(255, 255, 255, 255),
+        )

--- a/modular_robot/revolve2/modular_robot/body/base/_core.py
+++ b/modular_robot/revolve2/modular_robot/body/base/_core.py
@@ -1,4 +1,6 @@
-from pyrr import Vector3
+import math
+
+from pyrr import Quaternion, Vector3
 
 from .._attachment_point import AttachmentPoint
 from .._color import Color
@@ -26,7 +28,7 @@ class Core(Module):
         rotation: float | RightAngles,
         mass: float,
         bounding_box: Vector3,
-        attachment_points: dict[int, AttachmentPoint],
+        child_offset: float,
     ):
         """
         Initialize this object.
@@ -34,10 +36,29 @@ class Core(Module):
         :param rotation: The Modules rotation.
         :param mass: The Modules mass (in kg).
         :param bounding_box: The bounding box. Vector3 with sizes of bbox in x,y,z dimension (m). Sizes are total length, not half length from origin.
-        :param attachment_points: The attachment points for this core.
+        :param child_offset: The offset for the children.
         """
         self._mass = mass
         self._bounding_box = bounding_box
+
+        attachment_points = {
+            self.FRONT: AttachmentPoint(
+                offset=Vector3([child_offset, 0.0, 0.0]),
+                orientation=Quaternion.from_eulers([0.0, 0.0, 0.0]),
+            ),
+            self.BACK: AttachmentPoint(
+                offset=Vector3([child_offset, 0.0, 0.0]),
+                orientation=Quaternion.from_eulers([0.0, 0.0, math.pi]),
+            ),
+            self.LEFT: AttachmentPoint(
+                offset=Vector3([child_offset, 0.0, 0.0]),
+                orientation=Quaternion.from_eulers([0.0, 0.0, math.pi / 2.0]),
+            ),
+            self.RIGHT: AttachmentPoint(
+                offset=Vector3([child_offset, 0.0, 0.0]),
+                orientation=Quaternion.from_eulers([0.0, 0.0, math.pi / 2.0 * 3]),
+            ),
+        }
 
         super().__init__(rotation, Color(255, 50, 50, 255), attachment_points)
         self._parent = None
@@ -61,3 +82,75 @@ class Core(Module):
         :return: Vector3 with sizes of bbox in x,y,z dimension (m).
         """
         return self._bounding_box
+
+    @property
+    def front(self) -> Module | None:
+        """
+        Get the front module of the core.
+
+        :returns: The attachment points module.
+        """
+        return self._children.get(self.FRONT)
+
+    @front.setter
+    def front(self, module: Module) -> None:
+        """
+        Set a module onto the attachment point.
+
+        :param module: The Module.
+        """
+        self.set_child(module, self.FRONT)
+
+    @property
+    def right(self) -> Module | None:
+        """
+        Get the right module of the core.
+
+        :returns: The attachment points module.
+        """
+        return self._children.get(self.RIGHT)
+
+    @right.setter
+    def right(self, module: Module) -> None:
+        """
+        Set a module onto the attachment point.
+
+        :param module: The Module.
+        """
+        self.set_child(module, self.RIGHT)
+
+    @property
+    def back(self) -> Module | None:
+        """
+        Get the back module of the core.
+
+        :returns: The attachment points module.
+        """
+        return self._children.get(self.BACK)
+
+    @back.setter
+    def back(self, module: Module) -> None:
+        """
+        Set a module onto the attachment point.
+
+        :param module: The Module.
+        """
+        self.set_child(module, self.BACK)
+
+    @property
+    def left(self) -> Module | None:
+        """
+        Get the left module of the core.
+
+        :returns: The attachment points module.
+        """
+        return self._children.get(self.LEFT)
+
+    @left.setter
+    def left(self, module: Module) -> None:
+        """
+        Set a module onto the attachment point.
+
+        :param module: The Module.
+        """
+        self.set_child(module, self.LEFT)

--- a/modular_robot/revolve2/modular_robot/body/v1/_core_v1.py
+++ b/modular_robot/revolve2/modular_robot/body/v1/_core_v1.py
@@ -1,9 +1,5 @@
-import math
+from pyrr import Vector3
 
-from pyrr import Quaternion, Vector3
-
-from .._attachment_point import AttachmentPoint
-from .._module import Module
 from .._right_angles import RightAngles
 from ..base import Core
 
@@ -15,102 +11,11 @@ class CoreV1(Core):
         """
         Initialize this object.
 
-        :param rotation: The modules rotation.
+        :param rotation: The modules' rotation.
         """
-        attachment_points = {
-            self.FRONT: AttachmentPoint(
-                offset=Vector3([0.089 / 2.0, 0.0, 0.0]),
-                orientation=Quaternion.from_eulers([0.0, 0.0, 0.0]),
-            ),
-            self.BACK: AttachmentPoint(
-                offset=Vector3([0.089 / 2.0, 0.0, 0.0]),
-                orientation=Quaternion.from_eulers([0.0, 0.0, math.pi]),
-            ),
-            self.LEFT: AttachmentPoint(
-                offset=Vector3([0.089 / 2.0, 0.0, 0.0]),
-                orientation=Quaternion.from_eulers([0.0, 0.0, math.pi / 2.0]),
-            ),
-            self.RIGHT: AttachmentPoint(
-                offset=Vector3([0.089 / 2.0, 0.0, 0.0]),
-                orientation=Quaternion.from_eulers([0.0, 0.0, math.pi / 2.0 * 3]),
-            ),
-        }
-
         super().__init__(
             rotation=rotation,
             bounding_box=Vector3([0.089, 0.089, 0.0603]),
             mass=0.250,
-            attachment_points=attachment_points,
+            child_offset=0.089 / 2.0,
         )
-
-    @property
-    def front(self) -> Module | None:
-        """
-        Get the front module of the core.
-
-        :returns: The attachment points module.
-        """
-        return self._children.get(self.FRONT)
-
-    @front.setter
-    def front(self, module: Module) -> None:
-        """
-        Set a module onto the attachment point.
-
-        :param module: The Module.
-        """
-        self.set_child(module, self.FRONT)
-
-    @property
-    def right(self) -> Module | None:
-        """
-        Get the right module of the core.
-
-        :returns: The attachment points module.
-        """
-        return self._children.get(self.RIGHT)
-
-    @right.setter
-    def right(self, module: Module) -> None:
-        """
-        Set a module onto the attachment point.
-
-        :param module: The Module.
-        """
-        self.set_child(module, self.RIGHT)
-
-    @property
-    def back(self) -> Module | None:
-        """
-        Get the back module of the core.
-
-        :returns: The attachment points module.
-        """
-        return self._children.get(self.BACK)
-
-    @back.setter
-    def back(self, module: Module) -> None:
-        """
-        Set a module onto the attachment point.
-
-        :param module: The Module.
-        """
-        self.set_child(module, self.BACK)
-
-    @property
-    def left(self) -> Module | None:
-        """
-        Get the left module of the core.
-
-        :returns: The attachment points module.
-        """
-        return self._children.get(self.LEFT)
-
-    @left.setter
-    def left(self, module: Module) -> None:
-        """
-        Set a module onto the attachment point.
-
-        :param module: The Module.
-        """
-        self.set_child(module, self.LEFT)

--- a/modular_robot_simulation/revolve2/modular_robot_simulation/_build_multi_body_systems/_attachment_face_builder.py
+++ b/modular_robot_simulation/revolve2/modular_robot_simulation/_build_multi_body_systems/_attachment_face_builder.py
@@ -1,0 +1,52 @@
+from revolve2.modular_robot.body.base import AttachmentFace
+from revolve2.simulation.scene import MultiBodySystem, Pose, RigidBody
+
+from ._body_to_multi_body_system_mapping import BodyToMultiBodySystemMapping
+from ._builder import Builder
+from ._unbuilt_child import UnbuiltChild
+
+
+class AttachmentFaceBuilder(Builder):
+    """A Builder for Attachment Faces."""
+
+    _module: AttachmentFace
+
+    def __init__(self, module: AttachmentFace, rigid_body: RigidBody, slot_pose: Pose):
+        """
+        Initialize the Attachment Face Builder.
+
+        :param module: The module to be built.
+        :param rigid_body: The rigid body for the module to be built on.
+        :param slot_pose: The slot pose of the module.
+        """
+        self._module = module
+        self._rigid_body = rigid_body
+        self._slot_pose = slot_pose
+
+    def build(
+        self,
+        multi_body_system: MultiBodySystem,
+        body_to_multi_body_system_mapping: BodyToMultiBodySystemMapping,
+    ) -> list[UnbuiltChild]:
+        """
+        Build a module onto the Robot.
+
+        :param multi_body_system: The multi body system of the robot.
+        :param body_to_multi_body_system_mapping: A mapping from body to multi-body system
+        :return: The next children to be built.
+        """
+        tasks = []
+        for child_index, attachment_point in self._module.attachment_points.items():
+            child = self._module.children.get(child_index)
+            if child is not None:
+                unbuilt = UnbuiltChild(
+                    module=child,
+                    rigid_body=self._rigid_body,
+                )
+                unbuilt.make_pose(
+                    position=self._slot_pose.position
+                    + self._slot_pose.orientation * attachment_point.offset,
+                    orientation=self._slot_pose.orientation,
+                )
+                tasks.append(unbuilt)
+        return tasks

--- a/modular_robot_simulation/revolve2/modular_robot_simulation/_build_multi_body_systems/_get_builder.py
+++ b/modular_robot_simulation/revolve2/modular_robot_simulation/_build_multi_body_systems/_get_builder.py
@@ -1,6 +1,7 @@
-from revolve2.modular_robot.body.base import ActiveHinge, Brick, Core
+from revolve2.modular_robot.body.base import ActiveHinge, AttachmentFace, Brick, Core
 
 from ._active_hinge_builder import ActiveHingeBuilder
+from ._attachment_face_builder import AttachmentFaceBuilder
 from ._brick_builder import BrickBuilder
 from ._builder import Builder
 from ._core_builder import CoreBuilder
@@ -30,6 +31,12 @@ def get_builder(unbuilt_child: UnbuiltChild) -> Builder:
             )
         case ActiveHinge():
             return ActiveHingeBuilder(
+                module=unbuilt_child.module,
+                rigid_body=unbuilt_child.rigid_body,
+                slot_pose=unbuilt_child.pose,
+            )
+        case AttachmentFace():
+            return AttachmentFaceBuilder(
                 module=unbuilt_child.module,
                 rigid_body=unbuilt_child.rigid_body,
                 slot_pose=unbuilt_child.pose,


### PR DESCRIPTION
Simulating V2 Robots was bugged since the builders could not access modules on attachment faces.

The new structure is as follows:
-> Attachment Faces are modules themselves now
-> V2 Core gets attachment faces assigned by default as children
-> v2 development now doesn't take the core itself as a starting point, but its attachment faces.