### PR TITLE
Fixed classic render not rendering

### DIFF
--- a/simulation/revolve2/simulation/simulator/_viewer.py
+++ b/simulation/revolve2/simulation/simulator/_viewer.py
@@ -16,6 +16,7 @@ class Viewer(ABC):
 
         :returns: Nothing or feedback.
         """
+        raise NotImplementedError
 
     @abstractmethod
     def current_viewport_size(self) -> tuple[int, int]:

--- a/simulators/mujoco_simulator/revolve2/simulators/mujoco_simulator/viewers/_custom_mujoco_viewer.py
+++ b/simulators/mujoco_simulator/revolve2/simulators/mujoco_simulator/viewers/_custom_mujoco_viewer.py
@@ -244,7 +244,7 @@ class CustomMujocoViewer(Viewer, mujoco_viewer.MujocoViewer):  # type: ignore
 
         :return: A cycle position if applicable.
         """
-        super().render()
+        mujoco_viewer.MujocoViewer.render(self)
         if self._viewer_mode == CustomMujocoViewerMode.MANUAL:
             return self._position
         return None

--- a/simulators/mujoco_simulator/revolve2/simulators/mujoco_simulator/viewers/_custom_mujoco_viewer.py
+++ b/simulators/mujoco_simulator/revolve2/simulators/mujoco_simulator/viewers/_custom_mujoco_viewer.py
@@ -244,7 +244,6 @@ class CustomMujocoViewer(Viewer, mujoco_viewer.MujocoViewer):  # type: ignore
 
         :return: A cycle position if applicable.
         """
-        #super().render()
         mujoco_viewer.MujocoViewer.render(self)
         if self._viewer_mode == CustomMujocoViewerMode.MANUAL:
             return self._position

--- a/simulators/mujoco_simulator/revolve2/simulators/mujoco_simulator/viewers/_custom_mujoco_viewer.py
+++ b/simulators/mujoco_simulator/revolve2/simulators/mujoco_simulator/viewers/_custom_mujoco_viewer.py
@@ -244,6 +244,7 @@ class CustomMujocoViewer(Viewer, mujoco_viewer.MujocoViewer):  # type: ignore
 
         :return: A cycle position if applicable.
         """
+        #super().render()
         mujoco_viewer.MujocoViewer.render(self)
         if self._viewer_mode == CustomMujocoViewerMode.MANUAL:
             return self._position


### PR DESCRIPTION
The offending line delegates to the abstract `Viewer.render()` instead of `MujocoViewer.render()`.
Always raising `NotImplementedError` may also help catch future similar errors. I did so, as an illustration, for the offending render.