### PR TITLE
Optionally add CPGs to passive modules

### DIFF
--- a/examples/1_simulator_basics/1a_simulate_single_robot/main.py
+++ b/examples/1_simulator_basics/1a_simulate_single_robot/main.py
@@ -54,7 +54,7 @@ def main() -> None:
     We choose a 'CPG' brain with random parameters.
     If you want to know more about CPGs checkout the Methods section in: https://doi.org/10.1038/s41598-023-48338-4. 
     """
-    brain = BrainCpgNetworkNeighborRandom(body=body, rng=rng)
+    brain = BrainCpgNetworkNeighborRandom(body=body, rng=rng, passive_connections=False)
 
     """Once we have a body and a brain we combine it into a ModularRobot."""
     robot = ModularRobot(body, brain)

--- a/examples/1_simulator_basics/1b_custom_terrain/main.py
+++ b/examples/1_simulator_basics/1b_custom_terrain/main.py
@@ -7,6 +7,7 @@ from pyrr import Quaternion, Vector3
 from revolve2.experimentation.logging import setup_logging
 from revolve2.experimentation.rng import make_rng_time_seed
 from revolve2.modular_robot import ModularRobot
+from revolve2.modular_robot.body._module import Module
 from revolve2.modular_robot.brain.cpg import BrainCpgNetworkNeighborRandom
 from revolve2.modular_robot_simulation import (
     ModularRobotScene,
@@ -91,8 +92,12 @@ def main() -> None:
 
     # Create a robot
     body = gecko_v2()
-    brain = BrainCpgNetworkNeighborRandom(body=body, rng=rng)
+    brain = BrainCpgNetworkNeighborRandom(body=body, rng=rng, passive_connections=False)
     robot = ModularRobot(body, brain)
+
+    # You can inspect the number of modules and weight matrix like this
+    print(f"Body Modules: {len(body.find_modules_of_type(Module))}")
+    print(f"Brain Weights: {len(brain._weight_matrix)}")
 
     # Create the scene.
     scene = ModularRobotScene(terrain=make_custom_terrain())

--- a/examples/3_experiment_foundations/3b_evaluate_single_robot/main.py
+++ b/examples/3_experiment_foundations/3b_evaluate_single_robot/main.py
@@ -22,7 +22,7 @@ def main() -> None:
 
     # Create the robot.
     body = modular_robots_v2.gecko_v2()
-    brain = BrainCpgNetworkNeighborRandom(body=body, rng=rng)
+    brain = BrainCpgNetworkNeighborRandom(body=body, rng=rng, passive_connections=False)
     robot = ModularRobot(body, brain)
 
     # Create the scene.

--- a/examples/3_experiment_foundations/3c_evaluate_multiple_isolated_robots/main.py
+++ b/examples/3_experiment_foundations/3c_evaluate_multiple_isolated_robots/main.py
@@ -27,7 +27,10 @@ def main() -> None:
         modular_robots_v1.snake_v1(),
         modular_robots_v1.spider_v1(),
     ]
-    brains = [BrainCpgNetworkNeighborRandom(body, rng) for body in bodies]
+    brains = [
+        BrainCpgNetworkNeighborRandom(body, rng, passive_connections=False)
+        for body in bodies
+    ]
     robots = [ModularRobot(body, brain) for body, brain in zip(bodies, brains)]
 
     # Create a flat terrain

--- a/examples/3_experiment_foundations/3d_evaluate_multiple_interacting_robots/main.py
+++ b/examples/3_experiment_foundations/3d_evaluate_multiple_interacting_robots/main.py
@@ -30,7 +30,10 @@ def main() -> None:
         modular_robots_v2.snake_v2(),
         modular_robots_v2.spider_v2(),
     ]
-    brains = [BrainCpgNetworkNeighborRandom(body, rng) for body in bodies]
+    brains = [
+        BrainCpgNetworkNeighborRandom(body, rng, passive_connections=False)
+        for body in bodies
+    ]
     robots = [ModularRobot(body, brain) for body, brain in zip(bodies, brains)]
 
     """

--- a/examples/4_example_experiment_setups/4c_robot_bodybrain_ea/evaluator.py
+++ b/examples/4_example_experiment_setups/4c_robot_bodybrain_ea/evaluator.py
@@ -47,7 +47,7 @@ class Evaluator(Eval):
         :param population: The robots to simulate.
         :returns: Fitnesses of the robots.
         """
-        robots = [genotype.develop() for genotype in population]
+        robots = [genotype.develop(passive_connections=False) for genotype in population]
         # Create the scenes.
         scenes = []
         for robot in robots:

--- a/examples/4_example_experiment_setups/4c_robot_bodybrain_ea/genotype.py
+++ b/examples/4_example_experiment_setups/4c_robot_bodybrain_ea/genotype.py
@@ -77,12 +77,14 @@ class Genotype(BodyGenotypeV2, BrainGenotypeCpg):
 
         return Genotype(body=body.body, brain=brain.brain)
 
-    def develop(self) -> ModularRobot:
+    def develop(self, passive_connections: bool) -> ModularRobot:
         """
         Develop the genotype into a modular robot.
 
+        :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
+        not produce output and serve more as communication bridges.
         :returns: The created robot.
         """
         body = self.develop_body()
-        brain = self.develop_brain(body=body)
+        brain = self.develop_brain(body=body, passive_connections=passive_connections)
         return ModularRobot(body=body, brain=brain)

--- a/examples/4_example_experiment_setups/4d_robot_bodybrain_ea_database/database_components/_genotype.py
+++ b/examples/4_example_experiment_setups/4d_robot_bodybrain_ea_database/database_components/_genotype.py
@@ -79,12 +79,14 @@ class Genotype(Base, HasId, BodyGenotypeOrmV2, BrainGenotypeCpgOrm):
 
         return Genotype(body=body.body, brain=brain.brain)
 
-    def develop(self) -> ModularRobot:
+    def develop(self, passive_connections: bool) -> ModularRobot:
         """
         Develop the genotype into a modular robot.
 
+        :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
+        not produce output and serve more as communication bridges.
         :returns: The created robot.
         """
         body = self.develop_body()
-        brain = self.develop_brain(body=body)
+        brain = self.develop_brain(body=body, passive_connections=passive_connections)
         return ModularRobot(body=body, brain=brain)

--- a/examples/4_example_experiment_setups/4d_robot_bodybrain_ea_database/evaluator.py
+++ b/examples/4_example_experiment_setups/4d_robot_bodybrain_ea_database/evaluator.py
@@ -47,7 +47,9 @@ class Evaluator(Eval):
         :param population: The robots to simulate.
         :returns: Fitnesses of the robots.
         """
-        robots = [genotype.develop(passive_connections=False) for genotype in population]
+        robots = [
+            genotype.develop(passive_connections=False) for genotype in population
+        ]
         # Create the scenes.
         scenes = []
         for robot in robots:

--- a/examples/4_example_experiment_setups/4d_robot_bodybrain_ea_database/evaluator.py
+++ b/examples/4_example_experiment_setups/4d_robot_bodybrain_ea_database/evaluator.py
@@ -47,7 +47,7 @@ class Evaluator(Eval):
         :param population: The robots to simulate.
         :returns: Fitnesses of the robots.
         """
-        robots = [genotype.develop() for genotype in population]
+        robots = [genotype.develop(passive_connections=False) for genotype in population]
         # Create the scenes.
         scenes = []
         for robot in robots:

--- a/examples/5_physical_modular_robots/5a_physical_robot_remote/main.py
+++ b/examples/5_physical_modular_robots/5a_physical_robot_remote/main.py
@@ -57,7 +57,7 @@ def main() -> None:
     Of course, you can replace this with your own robot, such as one you have optimized using an evolutionary algorithm.
     """
     body, hinges = make_body()
-    brain = BrainCpgNetworkNeighborRandom(body=body, rng=rng)
+    brain = BrainCpgNetworkNeighborRandom(body=body, rng=rng, passive_connections=False)
     robot = ModularRobot(body, brain)
 
     """

--- a/modular_robot/pyproject.toml
+++ b/modular_robot/pyproject.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 authors = [
     "Aart Stuurman <aartstuurman@hotmail.com>",
     "Oliver Weissl <o.weissl@vu.nl>",
+    "Andres Garcia <a.a.garciarincon@student.vu.nl>"
 ]
 repository = "https://github.com/ci-group/revolve2"
 classifiers = [

--- a/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_instance.py
+++ b/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_instance.py
@@ -86,6 +86,9 @@ class BrainCpgInstance(BrainInstance):
 
         # Set active hinge targets to match newly calculated state.
         for state_index, active_hinge in self._output_mapping:
-            control_interface.set_active_hinge_target(
-                active_hinge, float(self._state[state_index]) * active_hinge.range
-            )
+            if not isinstance(active_hinge, ActiveHinge):
+                pass
+            else:
+                control_interface.set_active_hinge_target(
+                    active_hinge, float(self._state[state_index]) * active_hinge.range
+                )

--- a/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_network_neighbor.py
+++ b/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_network_neighbor.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 import numpy as np
 import numpy.typing as npt
 
+from ...body._module import Module
 from ...body.base import ActiveHinge, Body
 from .._brain import Brain
 from .._brain_instance import BrainInstance
@@ -24,13 +25,16 @@ class BrainCpgNetworkNeighbor(Brain):
     _weight_matrix: npt.NDArray[np.float_]  # nxn matrix matching number of neurons
     _output_mapping: list[tuple[int, ActiveHinge]]
 
-    def __init__(self, body: Body) -> None:
+    def __init__(self, body: Body, passive_connections: bool) -> None:
         """
         Initialize this object.
 
         :param body: The body to create the cpg network and brain for.
+        :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
+        not produce output and serve more as communication bridges.
         """
-        active_hinges = body.find_modules_of_type(ActiveHinge)
+        add_cpg_to = Module if passive_connections else ActiveHinge
+        active_hinges = body.find_modules_of_type(add_cpg_to)
         (
             cpg_network_structure,
             self._output_mapping,

--- a/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_network_neighbor_random.py
+++ b/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_network_neighbor_random.py
@@ -34,6 +34,18 @@ class BrainCpgNetworkNeighborRandom(BrainCpgNetworkNeighbor):
         connections: list[tuple[ActiveHinge, ActiveHinge]],
         body: Body,
     ) -> tuple[list[float], list[float]]:
+        """
+        Define the weights between neurons.
+
+        :param active_hinges: The active hinges corresponding to each cpg.
+        :param connections: Pairs of active hinges corresponding to pairs of cpgs that are connected.
+                            Connection is from hinge 0 to hinge 1.
+                            Opposite connection is not provided as weights are assumed to be negative.
+        :param body: The body that matches this brain.
+        :returns: Two lists. The first list contains the internal weights in cpgs, corresponding to `active_hinges`
+                 The second list contains the weights between connected cpgs, corresponding to `connections`
+                 The lists should match the order of the input parameters.
+        """
         return (
             (self._rng.random(size=len(active_hinges)) * 2.0 - 1).tolist(),
             (self._rng.random(size=len(connections)) * 2.0 - 1).tolist(),

--- a/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_network_neighbor_random.py
+++ b/modular_robot/revolve2/modular_robot/brain/cpg/_brain_cpg_network_neighbor_random.py
@@ -14,15 +14,19 @@ class BrainCpgNetworkNeighborRandom(BrainCpgNetworkNeighbor):
 
     _rng: np.random.Generator
 
-    def __init__(self, body: Body, rng: np.random.Generator) -> None:
+    def __init__(
+        self, body: Body, rng: np.random.Generator, passive_connections: bool
+    ) -> None:
         """
         Initialize this object.
 
         :param body: The body to create the cpg network and brain for.
         :param rng: Random number generator used for generating the weights.
+        :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
+        not produce output and serve more as communication bridges.
         """
         self._rng = rng
-        super().__init__(body)
+        super().__init__(body, passive_connections)
 
     def _make_weights(
         self,

--- a/modular_robot_simulation/revolve2/modular_robot_simulation/_modular_robot_control_interface_impl.py
+++ b/modular_robot_simulation/revolve2/modular_robot_simulation/_modular_robot_control_interface_impl.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from revolve2.modular_robot import ModularRobotControlInterface
+from revolve2.modular_robot.body._module import Module
 from revolve2.modular_robot.body.base import ActiveHinge
 from revolve2.simulation.scene import ControlInterface, UUIDKey
 
@@ -27,16 +28,19 @@ class ModularRobotControlInterfaceImpl(ModularRobotControlInterface):
         self._simulation_control = simulation_control
         self._body_to_multi_body_system_mapping = body_to_multi_body_system_mapping
 
-    def set_active_hinge_target(self, active_hinge: ActiveHinge, target: float) -> None:
+    def set_active_hinge_target(self, module: Module, target: float) -> None:
         """
         Set the position target for an active hinge.
 
-        :param active_hinge: The active hinge to set the target for.
+        :param module: The module to set the target for.
         :param target: The target to set.
         """
-        self._simulation_control.set_joint_hinge_position_target(
-            self._body_to_multi_body_system_mapping.active_hinge_to_joint_hinge[
-                UUIDKey(active_hinge)
-            ],
-            np.clip(target, a_min=-active_hinge.range, a_max=active_hinge.range),
-        )
+        if not isinstance(module, ActiveHinge):
+            pass
+        else:
+            self._simulation_control.set_joint_hinge_position_target(
+                self._body_to_multi_body_system_mapping.active_hinge_to_joint_hinge[
+                    UUIDKey(module)
+                ],
+                np.clip(target, a_min=-module.range, a_max=module.range),
+            )

--- a/standards/pyproject.toml
+++ b/standards/pyproject.toml
@@ -15,6 +15,7 @@ readme = "../README.md"
 authors = [
     "Aart Stuurman <aartstuurman@hotmail.com>",
     "Oliver Weissl <o.weissl@vu.nl>",
+    "Andres Garcia <a.a.garciarincon@student.vu.nl>"
 ]
 repository = "https://github.com/ci-group/revolve2"
 classifiers = [

--- a/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_cpg_network_neighbor.py
+++ b/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_cpg_network_neighbor.py
@@ -30,7 +30,6 @@ class BrainCpgNetworkNeighbor(ModularRobotBrainCpgNetworkNeighbor):
         :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
         not produce output and serve more as communication bridges.
         """
-
         self._genotype = genotype
         super().__init__(body, passive_connections)
 

--- a/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_cpg_network_neighbor.py
+++ b/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_cpg_network_neighbor.py
@@ -19,15 +19,19 @@ class BrainCpgNetworkNeighbor(ModularRobotBrainCpgNetworkNeighbor):
 
     _genotype: multineat.Genome
 
-    def __init__(self, genotype: multineat.Genome, body: Body):
+    def __init__(
+        self, genotype: multineat.Genome, body: Body, passive_connections: bool
+    ):
         """
         Initialize this object.
 
         :param genotype: A multineat genome used for determining weights.
         :param body: The body of the robot.
+        :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
+        not produce output and serve more as communication bridges.
         """
         self._genotype = genotype
-        super().__init__(body)
+        super().__init__(body, passive_connections)
 
     def _make_weights(
         self,

--- a/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_cpg_network_neighbor.py
+++ b/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_cpg_network_neighbor.py
@@ -30,7 +30,7 @@ class BrainCpgNetworkNeighbor(ModularRobotBrainCpgNetworkNeighbor):
         :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
         not produce output and serve more as communication bridges.
         """
-        
+
         self._genotype = genotype
         super().__init__(body, passive_connections)
 

--- a/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_cpg_network_neighbor.py
+++ b/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_cpg_network_neighbor.py
@@ -30,6 +30,7 @@ class BrainCpgNetworkNeighbor(ModularRobotBrainCpgNetworkNeighbor):
         :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
         not produce output and serve more as communication bridges.
         """
+        
         self._genotype = genotype
         super().__init__(body, passive_connections)
 
@@ -39,6 +40,18 @@ class BrainCpgNetworkNeighbor(ModularRobotBrainCpgNetworkNeighbor):
         connections: list[tuple[ActiveHinge, ActiveHinge]],
         body: Body,
     ) -> tuple[list[float], list[float]]:
+        """
+        Define the weights between neurons.
+
+        :param active_hinges: The active hinges corresponding to each cpg.
+        :param connections: Pairs of active hinges corresponding to pairs of cpgs that are connected.
+                            Connection is from hinge 0 to hinge 1.
+                            Opposite connection is not provided as weights are assumed to be negative.
+        :param body: The body that matches this brain.
+        :returns: Two lists. The first list contains the internal weights in cpgs, corresponding to `active_hinges`
+                 The second list contains the weights between connected cpgs, corresponding to `connections`
+                 The lists should match the order of the input parameters.
+        """
         brain_net = multineat.NeuralNetwork()
         self._genotype.BuildPhenotype(brain_net)
 

--- a/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_genotype_cpg.py
+++ b/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_genotype_cpg.py
@@ -111,11 +111,19 @@ class BrainGenotypeCpg:
             )
         )
 
-    def develop_brain(self, body: Body) -> BrainCpgNetworkNeighbor:
+    def develop_brain(
+        self, body: Body, passive_connections: bool
+    ) -> BrainCpgNetworkNeighbor:
         """
         Develop the genotype into a modular robot.
 
         :param body: The body to develop the brain for.
+        :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
+        not produce output and serve more as communication bridges.
         :returns: The created robot.
         """
-        return BrainCpgNetworkNeighbor(genotype=self.brain.genotype, body=body)
+        return BrainCpgNetworkNeighbor(
+            genotype=self.brain.genotype,
+            body=body,
+            passive_connections=passive_connections,
+        )

--- a/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_genotype_cpg_orm.py
+++ b/standards/revolve2/standards/genotypes/cppnwin/modular_robot/_brain_genotype_cpg_orm.py
@@ -108,14 +108,20 @@ class BrainGenotypeCpgOrm(orm.MappedAsDataclass, kw_only=True):
             )
         )
 
-    def develop_brain(self, body: Body) -> BrainCpgNetworkNeighbor:
+    def develop_brain(
+        self, body: Body, passive_connections: bool
+    ) -> BrainCpgNetworkNeighbor:
         """
         Develop the genotype into a modular robot.
 
         :param body: The body to develop the brain for.
+        :param passive_connections: Wether to add CPGs also to passive body modules. The passive module CPGs will
+        not produce output and serve more as communication bridges.
         :returns: The created robot.
         """
-        return BrainCpgNetworkNeighbor(genotype=self.brain, body=body)
+        return BrainCpgNetworkNeighbor(
+            genotype=self.brain, body=body, passive_connections=passive_connections
+        )
 
 
 @event.listens_for(BrainGenotypeCpgOrm, "before_update", propagate=True)


### PR DESCRIPTION
1. Added option to add CPGs to passive modules in addition to active ones
2. CPGs on passive modules are not assigned a target and thus cannot be controlled and do not produce an output
3. It was discovered that doing so results in better fitness, thus we added the option to do so so users can experiment with it
4. Example scripts that utilized it were updated