### PR TITLE
Bugfix: incorrect CPPN output is used to determine the angle for a robot body module

### DIFF
--- a/standards/revolve2/standards/genotypes/cppnwin/modular_robot/v2/_body_develop.py
+++ b/standards/revolve2/standards/genotypes/cppnwin/modular_robot/v2/_body_develop.py
@@ -106,7 +106,7 @@ def __evaluate_cppn(
     
     The output ranges between [0,1] and we have 4 rotations available (0, 90, 180, 270).
     """
-    angle = max(0, int(outputs[0] * 4 - 1e-6)) * (np.pi / 2.0)
+    angle = max(0, int(outputs[1] * 4 - 1e-6)) * (np.pi / 2.0)
 
     return module_type, angle
 


### PR DESCRIPTION
Both angle and module_type use outputs[0] from the CPPN, where one would expect module_type to use `outputs[0]` and angle to use `outputs[1]`, as can be deduced from this code snippet in class `BodyGenotypeOrmV2` 

```
        body = MultineatGenotypePickleWrapper(
            random_multineat_genotype(
                [...]
                num_outputs=2,  # block_type, rotation_type
                [...]
            )
        )
```

See https://github.com/ci-group/revolve2/blob/6d3457af6e9928deacc352a365e2cf910f4d20cd/standards/revolve2/standards/genotypes/cppnwin/modular_robot/v2/_body_genotype_orm_v2.py