### PR TITLE
Bug fix: catch errors when a camera is not attached

### DIFF
--- a/docs/source/physical_robot_core_setup/index.rst
+++ b/docs/source/physical_robot_core_setup/index.rst
@@ -39,7 +39,8 @@ On the RPi adjust the config in `/boot/config.txt` or on newer systems `/boot/fi
 ------------------
 Setting up the RPi
 ------------------
-**Note**: For students in the CI Group, the RPi is already set up. All RPis are flashed with the same image, so the following steps are not necessary. Additionally, there should be an IP address on the head, allowing you to SSH into it. However, be aware that there will always be ongoing development changes in the revolve2-modular-robot_physical and revolve2-robohat packages, so make sure to pip install the latest version in your virtual environment.
+**Note**: For students in the CI Group, the RPi is already set up. All RPis are flashed with the same image, so the following steps are not necessary. Additionally, there should be an IP address on the head, allowing you to SSH into it under the *ThymioNet* Wi-Fi. However, be aware that the IP might change from time to time. If you find the IP doesn't work, use the serial connection to log in and obtain the correct IP. For instructions on how to establish a serial connection, please refer to the section below.
+Also, note that ongoing development changes will continue in revolve2-modular-robot_physical and revolve2-robohat packages, so make sure to pip install the latest version in your virtual environment.
 
 This step is the same for all types of hardware.
 
@@ -135,6 +136,7 @@ Setting up Revolve2 on the robot requires different steps, depending on the hard
     #. Here, the :code:`Nice=-10` line sets a high priority for the daemon (lower values are higher priority, with -20 being the highest priority). The :code:`-l` option in the :code:`ExecStart` line tells :code:`robot-daemon` to only listen on the localhost interface. The :code:`-n localhost` option ensures that robot-daemon only runs if it can connect to localhost (preventing certain failure cases).
     #. Enable and start the service: :code:`sudo systemctl daemon-reload` & :code:`sudo systemctl enable robot-daemon` & :code:`sudo systemctl start robot-daemon`.
     #. Check if it is running properly using: :code:`sudo systemctl status robot-daemon`
+    #. If it's not running properly, check the logs using: :code:`journalctl -u robot-daemon -e`
 
 ^^^^^^^^^^^^^^^^^^^
 V1 Additional Steps

--- a/examples/5_physical_modular_robots/5a_physical_robot_remote/main.py
+++ b/examples/5_physical_modular_robots/5a_physical_robot_remote/main.py
@@ -43,7 +43,7 @@ def make_body() -> (
         body.core_v2.right_face.bottom,
         body.core_v2.right_face.bottom.attachment,
     )
-    """Add a camera sensor to the core."""
+    """Here we add a camera sensor to the core. If you don't have a physical camera attached, uncomment this line."""
     body.core.add_sensor(
         CameraSensor(position=Vector3([0, 0, 0]), camera_size=(480, 640))
     )

--- a/modular_robot_physical/pyproject.toml
+++ b/modular_robot_physical/pyproject.toml
@@ -32,7 +32,7 @@ pyrr = "^0.10.3"
 typed-argparse = "^0.3.1"
 pycapnp = { version = "^2.0.0b2" }
 pigpio = { version = "^1.78", optional = true }
-revolve2-robohat = { version = "0.6.2", optional = true }
+revolve2-robohat = { version = "0.6.3", optional = true }
 rpi-lgpio = { version = "0.5", optional = true  }
 opencv-python = "^4.10.0.84"
 # cpnp-stub-generator is disabled because it depends on pycapnp <2.0.0.

--- a/modular_robot_physical/revolve2/modular_robot_physical/remote/_remote.py
+++ b/modular_robot_physical/revolve2/modular_robot_physical/remote/_remote.py
@@ -321,6 +321,7 @@ def _get_camera_sensor_state(
     :param camera_sensor: The sensor in question.
     :param sensor_readings: The sensor readings.
     :return: The Sensor state.
+    :raises RuntimeError: If the camera image is empty.
     """
     if camera_sensor is None:
         return {}
@@ -348,6 +349,7 @@ def _display_camera_view(
 
     :param camera_sensor: The sensor in question.
     :param sensor_readings: The sensor readings.
+    :raises RuntimeError: If the camera image is empty.
     """
     if camera_sensor is None:
         print("No camera added in the body.")

--- a/modular_robot_physical/revolve2/modular_robot_physical/remote/_remote.py
+++ b/modular_robot_physical/revolve2/modular_robot_physical/remote/_remote.py
@@ -7,7 +7,6 @@ import cv2
 import numpy as np
 from numpy.typing import NDArray
 from pyrr import Vector3
-
 from revolve2.modular_robot.body.base import ActiveHinge
 from revolve2.modular_robot.body.sensors import CameraSensor, IMUSensor
 from revolve2.modular_robot.sensor_state import ModularRobotSensorState
@@ -327,7 +326,9 @@ def _get_camera_sensor_state(
     else:
         image = sensor_readings.cameraView
         if list(image.r) == [0] and list(image.g) == [0] and list(image.b) == [0]:
-            raise RuntimeError("Camera image is emtpy. Are you sure you have attached a camera?")
+            raise RuntimeError(
+                "Camera image is emtpy. Are you sure you have attached a camera?"
+            )
         return {
             UUIDKey(camera_sensor): CameraSensorStateImpl(
                 _capnp_to_camera_view(
@@ -352,7 +353,9 @@ def _display_camera_view(
     else:
         image = sensor_readings.cameraView
         if list(image.r) == [0] and list(image.g) == [0] and list(image.b) == [0]:
-            raise RuntimeError("Camera image is emtpy. Are you sure you have attached a camera?")
+            raise RuntimeError(
+                "Camera image is emtpy. Are you sure you have attached a camera?"
+            )
         rgb_image = _capnp_to_camera_view(
             sensor_readings.cameraView, camera_sensor.camera_size
         )

--- a/modular_robot_physical/revolve2/modular_robot_physical/remote/_remote.py
+++ b/modular_robot_physical/revolve2/modular_robot_physical/remote/_remote.py
@@ -325,6 +325,9 @@ def _get_camera_sensor_state(
     if camera_sensor is None:
         return {}
     else:
+        image = sensor_readings.cameraView
+        if list(image.r) == [0] and list(image.g) == [0] and list(image.b) == [0]:
+            raise RuntimeError("Camera image is emtpy. Are you sure you have attached a camera?")
         return {
             UUIDKey(camera_sensor): CameraSensorStateImpl(
                 _capnp_to_camera_view(
@@ -345,8 +348,11 @@ def _display_camera_view(
     :param sensor_readings: The sensor readings.
     """
     if camera_sensor is None:
-        print("No camera sensor found.")
+        print("No camera added in the body.")
     else:
+        image = sensor_readings.cameraView
+        if list(image.r) == [0] and list(image.g) == [0] and list(image.b) == [0]:
+            raise RuntimeError("Camera image is emtpy. Are you sure you have attached a camera?")
         rgb_image = _capnp_to_camera_view(
             sensor_readings.cameraView, camera_sensor.camera_size
         )

--- a/modular_robot_physical/revolve2/modular_robot_physical/remote/_remote.py
+++ b/modular_robot_physical/revolve2/modular_robot_physical/remote/_remote.py
@@ -7,6 +7,7 @@ import cv2
 import numpy as np
 from numpy.typing import NDArray
 from pyrr import Vector3
+
 from revolve2.modular_robot.body.base import ActiveHinge
 from revolve2.modular_robot.body.sensors import CameraSensor, IMUSensor
 from revolve2.modular_robot.sensor_state import ModularRobotSensorState


### PR DESCRIPTION
1. Update the RoboHat version that includes a bug fix for catching errors when no camera is attached.
2. Clarify the documentation.